### PR TITLE
Doesn't build on GHC 7.10

### DIFF
--- a/cndict.cabal
+++ b/cndict.cabal
@@ -26,7 +26,7 @@ source-repository head
 library
   exposed-modules:     Data.Chinese.CCDict, Data.Chinese.Pinyin, Data.Chinese.Frequency
   -- other-modules:
-  build-depends:       base       == 4.*,
+  build-depends:       base       >= 4 && < 4.8
                        text       >= 0.11.0.0,
                        file-embed >= 0.0.4.9,
                        containers >= 0.5.0.0,


### PR DESCRIPTION
Build errors: http://matrix.hackage.haskell.org/package/cndict#GHC-7.10/cndict-0.6.1

I've revised existing versions on hackage http://hackage.haskell.org/package/cndict/revisions/
